### PR TITLE
Patch to fix t2 miasma and other misses

### DIFF
--- a/hook/lua/loudutilities.lua
+++ b/hook/lua/loudutilities.lua
@@ -3,3 +3,14 @@ function SpawnWaveThread( aiBrain )
 	LOG("*AI DEBUG "..aiBrain.Nickname.." Spawnwave disabled")
 	aiBrain.WaveThread = nil
 end
+
+
+--destructively hook TrackProj to eliminate broken projectiles
+--that target M28 (e.g. miasma and others).
+--this could be oversight and "should" be fixed upstream.
+--for now we just make it behave identical to other AI
+--personalities.
+
+function TrackProj(projectitem, self)
+
+end


### PR DESCRIPTION
Looks like upstream introduced an odd TrackProj function that is invoked only
when the target has "m" in the AI name (e.g. only for m28).

This manifested in several odd bugs, namely aeon artillery miasma projectiles
just flying over targets entirely, IFF the targets were m28AI controlled.

e.g. for LOUD, everything works fine.

We eventually isolated the problem to the "new" circa 7.10/11 introduction of
the TrackProj monitor invoked on the projectile in defaultweapons.lua.

This patch hooks the function and turns it into a noop, which allows projectiles
to travel unimpeded (as they do with LOUD).

My testing shows this fixes the miasma and chariss (and anything else with a 
bp.DetonateBelowHeight and bp.DetonateBelowHeight > 0).