### PR TITLE
Multiple Fixes to AA Misfires

### DIFF
--- a/units/BlackOpsUnleashed/BELK002/BELK002_unit.bp
+++ b/units/BlackOpsUnleashed/BELK002/BELK002_unit.bp
@@ -4,7 +4,7 @@ UnitBlueprint {
 
       Weapon = {
         {
-        
+            RackSalvoReloadTime = 0, --base has RSRLT, drops dps to 295 from advertised 320  
             RateOfFire = 10/10,
 
             TurretPitchRange = 60,

--- a/units/LOUD Unit Additions/VAB2302/VAB2302_unit.bp
+++ b/units/LOUD Unit Additions/VAB2302/VAB2302_unit.bp
@@ -1,0 +1,11 @@
+UnitBlueprint {
+  Merge = true,
+  BlueprintId = "vab2302",
+
+      Weapon = {
+        {
+            EnergyRequired = 1600,
+
+	  },
+  },
+}

--- a/units/LOUD Unit Additions/VEB2302/VEB2302_unit.bp
+++ b/units/LOUD Unit Additions/VEB2302/VEB2302_unit.bp
@@ -1,0 +1,11 @@
+UnitBlueprint {
+  Merge = true,
+  BlueprintId = "veb2302",
+
+      Weapon = {
+        {
+            EnergyRequired = 1600,
+
+	  },
+  },
+}

--- a/units/LOUD Unit Additions/VRB2302/VRB2302_unit.bp
+++ b/units/LOUD Unit Additions/VRB2302/VRB2302_unit.bp
@@ -1,0 +1,11 @@
+UnitBlueprint {
+  Merge = true,
+  BlueprintId = "vrb2302",
+
+      Weapon = {
+        {
+            EnergyRequired = 1600,
+
+	  },
+  },
+}

--- a/units/LOUD Unit Additions/VSB2302/VSB2302_unit.bp
+++ b/units/LOUD Unit Additions/VSB2302/VSB2302_unit.bp
@@ -1,0 +1,11 @@
+UnitBlueprint {
+  Merge = true,
+  BlueprintId = "vsb2302",
+
+      Weapon = {
+        {
+            EnergyRequired = 1600,
+
+	  },
+  },
+}

--- a/units/Vanilla/UAB3304/UAB3304_unit.bp
+++ b/units/Vanilla/UAB3304/UAB3304_unit.bp
@@ -51,7 +51,7 @@ UnitBlueprint {
 			
 			ProjectileLifetimeUsesMultiplier = 1.25,
 			
-            RackSalvoChargeTime = 0.1,
+            RackSalvoChargeTime = 0, --drops DPS from 320 (advertised) to 270 if we use 0.1,
 
             RackSalvoReloadTime = 0.4,
 

--- a/units/Vanilla/UAL0205/UAL0205_unit.bp
+++ b/units/Vanilla/UAL0205/UAL0205_unit.bp
@@ -76,7 +76,7 @@ UnitBlueprint {
 			
             ProjectileLifetimeUsesMultiplier = 1.25,
 
-            RackSalvoChargeTime = 0.1,
+            RackSalvoChargeTime = 0, -- bad xfer, 0 in faf. 0.1 causes 1/2 ROF
 
             RangeCategory = 'UWRC_AntiAir',
 			

--- a/units/Vanilla/XSB2304/XSB2304_unit.bp
+++ b/units/Vanilla/XSB2304/XSB2304_unit.bp
@@ -25,7 +25,7 @@ UnitBlueprint {
             CannotAttackGround = true,
             CollideFriendly = false,
 			
-            Damage = 275,
+            Damage = 600, --ends up at 545 DPS.
             DamageRadius = 0,
             DamageType = 'Normal',
 			

--- a/units/Vanilla/XSB3304/XSB3304_unit.bp
+++ b/units/Vanilla/XSB3304/XSB3304_unit.bp
@@ -60,7 +60,7 @@ UnitBlueprint {
             ProjectilesPerOnFire = 2,
 
             RackFireTogether = true,
-            RackSalvoChargeTime = 0.1,
+            RackSalvoChargeTime = 0, --0.1 induces onfire misses, 1/2 ROf...
             RenderFireClock = true,
             RackSalvoFiresAfterCharge = true,
             RackSalvoSize = 1,

--- a/units/Vanilla/XSL0205/XSL0205_unit.bp
+++ b/units/Vanilla/XSL0205/XSL0205_unit.bp
@@ -76,7 +76,7 @@ UnitBlueprint {
 			
             ProjectileLifetimeUsesMultiplier = 1.25,
 
-            RackSalvoChargeTime = 0.1,
+            RackSalvoChargeTime = 0, --bad xfer, not present in faf. 0.1 causes 1/2 ROF
 
             RangeCategory = 'UWRC_AntiAir',
 			


### PR DESCRIPTION
Tested each unit against 2.04.

Includes review of t1, t2, t3, t4 mobile and static aa.
Several units were being hampered by 1/2 ROF vs. what the numbers suggested.

Did not look at mobile t4 AA (land, air, or navy).  Did 
not examine air.

xsb2304 sera t3 static - 1/2 damage
Damage = 600, --275,  545 dps

xsb3304 sera t3 flak
RackSalvoChargeTime = 0, -- 0.1,

xsl0205 sera t2 flak
RackSalvoChargeTime = 0, --0.1,

ual0205 aeon t2 mobile -

72 dps, should be 144 (only firing 1x second, ROF is 20/10, so 2x). RackSalvoChargeTime = 0.0, --0.1 fixes it.

faf ascendant has 0.1 MuzzleChargeDelay, 0 RackSalvoDelay, 0 RackSalvoChargeTime....

marris uab3304
doing ~270, advertised 320.
RackSalvoChargeTime = 0, --0.1,

uef cougar belk002
advertised 320 dps, hitting 295...
no big changes from base...
RackSalvoReloadTime = 0,

Flayer-II T4 sam VEB2302
Doing 1/2 dps.  ROF is out of sync with charge junk, or how it was previously.
8k every 5s.

Looks like ROF isn't syncing with econ drain at 2.5s, so it continues for another
cycle at 5s.  There's no reason for this, but here we are.

EnergyRequired = 1600,
same for
VAB2302
VRB2302
VSB2302

navy

aeon
keefer only fires everything if attack moved
aeon t3 aa cruiser only fires all aa missile turrets at one target if it's
in front, otherwise have to shoot at multiple targets on either side to get full effect.

no changes to navy, just noted.